### PR TITLE
Adding 3d building option

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,8 +457,7 @@ function MapBoxChart(props) {
     return (
         <div >
 
-            <MapBox data={sampleInputs.data} map={sampleInputs.map} slideshow={sampleInputs.slideshow}
-            source={sampleInputs.source} layer={sampleInputs.layer}/>
+            <MapBox data={sampleInputs.data} map={sampleInputs.map} />
         </div>
     );
 }

--- a/README.md
+++ b/README.md
@@ -402,3 +402,66 @@ export default MapBoxChart;
     }
     ]
  ```
+ 
+ 
+ 
+ #7 3d building layers
+ 
+ ![mapbox_Ex7_3d-building](https://user-images.githubusercontent.com/52831199/92612903-4d89b080-f2f5-11ea-99d8-92dccea2c997.PNG)
+ 
+ You can simply set 3d building layers with building3d props value as true
+ ```bsh
+ data:{
+       ...
+ },
+ map:{
+     canvas:{
+            ...
+         building3d:true,
+ ```
+ 
+ Here's an simple sample code of above picture.
+ 
+ ```bsh
+ import React from 'react';
+import { MapBox } from '@stickyboard/mapbox';
+
+const sampleInputs = {
+    data:{
+        mapboxKey:'YOUR MAPBOX KEY VALUE HERE!!!',
+        title:'Stickyboard-mapbox example',
+        description: 'This component is one of stickers in Stickyboard',
+    },
+    map:{
+        canvas:{
+            style:0,
+            building3d:true,
+            size:{
+                width:'600px',
+                height:'600px'
+            },
+            scrollZoom:true
+        },
+        camera:{
+            center: [126.939016,  37.519961],
+            zoom: 16.5,
+            pitch:30,
+            bearing:-20,
+            centerTheMapOnAClick:true
+        },
+    },
+}
+
+function MapBoxChart(props) {
+    
+    return (
+        <div >
+
+            <MapBox data={sampleInputs.data} map={sampleInputs.map} slideshow={sampleInputs.slideshow}
+            source={sampleInputs.source} layer={sampleInputs.layer}/>
+        </div>
+    );
+}
+
+export default MapBoxChart;
+ ```

--- a/src/MapBox.js
+++ b/src/MapBox.js
@@ -38,7 +38,58 @@ const mapboxStyle=[
   'mapbox://styles/mapbox/satellite-streets-v11',
   'mapbox://styles/mapbox/outdoors-v11',
 ]
+const building3dLayer = {
+  'id': '3d-buildings',
+  'source': 'composite',
+  'source-layer': 'building',
+  'filter': ['==', 'extrude', 'true'],
+  'type': 'fill-extrusion',
+  'minzoom': 15,
+  'paint': {
+    'fill-extrusion-color': '#aaa',
+    
+    // use an 'interpolate' expression to add a smooth transition effect to the
+    // buildings as the user zooms in
+    'fill-extrusion-height': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        15,
+        0,
+        15.05,
+        ['get', 'height']
+      ],
+      'fill-extrusion-base': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        15,
+        0,
+        15.05,
+        ['get', 'min_height']
+      ],
+    'fill-extrusion-opacity': 0.6
+    }
+  }
+  const add3dBuildingLayer = (map) => {
+
+    var layers = map.getStyle().layers;
+          
+    var labelLayerId;
+    for (var i = 0; i < layers.length; i++) {
+      if (layers[i].type === 'symbol' && layers[i].layout['text-field']) {
+        labelLayerId = layers[i].id;
+        break;
+      }
+    }
+
+    map.addLayer(
+      building3dLayer,
+      labelLayerId
+    );
+  }
 function MapBox(props) {
+  
     mapboxgl.accessToken = props.data.mapboxKey;
 
     
@@ -73,11 +124,15 @@ function MapBox(props) {
       if(!props.map.canvas.scrollZoom)
         mMap.scrollZoom.disable();
 
-      mMap.on('load', () => {
-        mMap.resize();
-        setMap(mMap);
+        mMap.on('load', () => {
+          mMap.resize();
+          if(props.map.canvas.building3d){
+            add3dBuildingLayer(mMap);
+          }
+          setMap(mMap);
+          
+        });
         
-      });
       
     };
 
@@ -225,6 +280,8 @@ function MapBox(props) {
     )
 }
 
+
+
 MapBox.propTypes ={
   data:PropTypes.shape({
     mapboxKey:PropTypes.string.isRequired,
@@ -234,6 +291,7 @@ MapBox.propTypes ={
   map:PropTypes.shape({
     canvas:PropTypes.shape({
       style:PropTypes.number,
+      building3d:PropTypes.bool,
       size:PropTypes.shape({
         width:PropTypes.string,
         height:PropTypes.string

--- a/src/MapBox.js
+++ b/src/MapBox.js
@@ -69,8 +69,8 @@ const building3dLayer = {
         ['get', 'min_height']
       ],
     'fill-extrusion-opacity': 0.6
-    }
   }
+}
   const add3dBuildingLayer = (map) => {
 
     var layers = map.getStyle().layers;


### PR DESCRIPTION
I added props which will help user to add 3d building layer easily.

User can set 3d building layer with "building3d" as true in props.map.canvas.

Sample code and picture were updated in Readme file.